### PR TITLE
Consolidate logging helpers

### DIFF
--- a/desktop video/desktop video/AppDelegate.swift
+++ b/desktop video/desktop video/AppDelegate.swift
@@ -48,11 +48,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var displaySleepAssertionID: IOPMAssertionID = 0
     // Track external suppression of screensaver
     private var otherAppSuppressScreensaver: Bool = false
-    
+
     // UserDefaults keys
     private let screensaverEnabledKey = "screensaverEnabled"
     private let screensaverDelayMinutesKey = "screensaverDelayMinutes"
-    
+
     private var cancellables = Set<AnyCancellable>()
 
     // 防抖：上次屏保检查时间
@@ -65,10 +65,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         dlog("applicationDidFinishLaunching")
         AppDelegate.shared = self
-        
+
         // 从书签中恢复窗口
         SharedWallpaperWindowManager.shared.restoreFromBookmark()
-        
+
         // Docker / 菜单栏切换
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             let showOnlyInMenuBar = UserDefaults.standard.bool(forKey: "isMenuBarOnly")
@@ -88,14 +88,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             name: NSWorkspace.activeSpaceDidChangeNotification,
             object: nil
         )
-        
+
         // Observe screensaver settings changes and start screensaver timer
         NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
             .sink { [weak self] _ in
                 self?.startScreensaverTimer()
             }
             .store(in: &cancellables)
-        
+
         // Observe app active/inactive notifications to reset screensaver timer
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActiveNotification), name: NSApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidResignActiveNotification), name: NSApplication.didResignActiveNotification, object: nil)
@@ -115,7 +115,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     // MARK: - Screensaver Timer Methods
-    
+
     func startScreensaverTimer() {
         dlog("startScreensaverTimer isInScreensaver=\(isInScreensaver) otherAppSuppressScreensaver=\(otherAppSuppressScreensaver) url=\(AppState.shared.currentMediaURL ?? "None")")
         // Check for external suppression first
@@ -189,7 +189,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         return TimeInterval(idleNS) / 1_000_000_000
     }
-    
+
     @objc func runScreenSaver() {
 //        return
         dlog("runScreenSaver isInScreensaver=\(isInScreensaver)")
@@ -291,7 +291,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // 2. 延迟 0.5 秒后再添加事件监听器并设置 isInScreensaver
         eventMonitors.forEach { NSEvent.removeMonitor($0) }
         eventMonitors.removeAll()
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             let eventTypes: [NSEvent.EventTypeMask] = [.any]
             for eventType in eventTypes {
@@ -312,7 +312,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self.isInScreensaver = true
         }
     }
-    
+
     func closeScreensaverWindows() {
         dlog("closeScreensaverWindows")
         if !isInScreensaver { return }
@@ -368,7 +368,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // 3. 重置屏保计时器
         startScreensaverTimer()
     }
-    
+
     @objc private func applicationDidBecomeActiveNotification() {
         dlog("applicationDidBecomeActiveNotification")
         // Only close screensaver if currently in screensaver
@@ -400,7 +400,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     static func openPreferencesWindow() {
         dlog("openPreferencesWindow")
         guard let delegate = shared else { return }
-        
+
         if let win = delegate.preferencesWindow {
             win.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
@@ -486,7 +486,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applyAppAppearanceSetting(onlyShowInMenuBar: Bool) {
         dlog("applyAppAppearanceSetting onlyShowInMenuBar=\(onlyShowInMenuBar)")
         appearanceChangeWorkItem?.cancel()
-        
+
         let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
             self.lastAppearanceChangeTime = Date()
@@ -499,7 +499,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             self.statusBarIconClicked()
         }
-        
+
         appearanceChangeWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
     }
@@ -538,7 +538,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
         }
     }
-    
+
     // 删除菜单栏图标
     func removeStatusBarIcon() {
         dlog("removeStatusBarIcon")
@@ -600,7 +600,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             isPausedDueToIdle = false
         }
     }
-    
+
     /// 判断指定屏幕是否需要暂停视频
     private func shouldPauseVideo(on screen: NSScreen) -> Bool {
         dlog("shouldPauseVideo on \(screen.dv_localizedName)")

--- a/desktop video/desktop video/SharedWallpaperWindowManager.swift
+++ b/desktop video/desktop video/SharedWallpaperWindowManager.swift
@@ -1,14 +1,3 @@
-// Debug log helper. Messages appear in Xcode's console / stdout when built in DEBUG mode
-func dlog(_ message: String, function: String = #function) {
-#if DEBUG
-    let formatter = DateFormatter()
-    formatter.dateFormat = "HH:mm:ss.SSS"
-    let timestamp = formatter.string(from: Date())
-    print("[\(timestamp)] \(function): \(message)")
-#endif
-}
-/// Synchronize the wallpaper content from a source screen to a target screen.
-
 //
 //  WallpaperWindow 2.swift
 //  desktop video
@@ -208,7 +197,7 @@ class SharedWallpaperWindowManager {
             let data = try Data(contentsOf: url)
             showVideoFromMemory(for: screen, data: data, stretch: stretch, volume: desktop_videoApp.shared!.globalMute ? 0.0 : volume, originalURL: url, onReady: onReady)
         } catch {
-            print("Cannot load from memory!")
+            errorLog("Cannot load from memory!")
         }
     }
     
@@ -350,7 +339,7 @@ class SharedWallpaperWindowManager {
         guard let displayID = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value else { return }
         do {
             guard url.startAccessingSecurityScopedResource() else {
-                dlog("Failed to access security scoped resource for saving bookmark: \(url)")
+                errorLog("Failed to access security scoped resource for saving bookmark: \(url)")
                 return
             }
             let bookmarkData = try url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
@@ -361,7 +350,7 @@ class SharedWallpaperWindowManager {
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "savedAt-\(displayID)")
             url.stopAccessingSecurityScopedResource()
         } catch {
-            dlog("Failed to save bookmark for \(url): \(error)")
+            errorLog("Failed to save bookmark for \(url): \(error)")
         }
     }
     
@@ -398,7 +387,7 @@ class SharedWallpaperWindowManager {
                     showImage(for: screen, url: url, stretch: stretch)
                 }
             } catch {
-                dlog("Failed to restore bookmark for screen \(displayID): \(error)")
+                errorLog("Failed to restore bookmark for screen \(displayID): \(error)")
             }
         }
     }
@@ -575,7 +564,7 @@ class SharedWallpaperWindowManager {
         do {
             try data.write(to: tempURL)
         } catch {
-            dlog("Failed to write video data to temp file: \(error)")
+            errorLog("Failed to write video data to temp file: \(error)")
             return
         }
         

--- a/desktop video/desktop video/desktop_videoApp.swift
+++ b/desktop video/desktop video/desktop_videoApp.swift
@@ -35,7 +35,7 @@ struct desktop_videoApp: App {
                     showAboutDialog()
                 }
             }
-            
+
             // Replace the default Settings menu to prevent conflicts
             CommandGroup(replacing: .appSettings) {
                 Button(L("Preferences…")) {
@@ -45,7 +45,7 @@ struct desktop_videoApp: App {
             }
         }
     }
-    
+
     /// 切换静音的统一处理（菜单命令也会调用）
     static func applyGlobalMute(_ enabled: Bool) {
         dlog("applyGlobalMute \(enabled)")
@@ -224,7 +224,7 @@ struct PreferencesView: View {
         if launchAtLogin != launchAtLoginStorage {
             handleLaunchAtLoginChange()
         }
-        
+
         desktop_videoApp.applyGlobalMute(globalMute)
     }
 
@@ -267,7 +267,7 @@ private func handleLaunchAtLoginChange() {
         task.launch()
         NSApp.terminate(nil)
     }
-    
+
     private func showRestartAlert() {
         dlog("showRestartAlert")
         let alert = NSAlert()
@@ -276,7 +276,7 @@ private func handleLaunchAtLoginChange() {
         alert.alertStyle = .informational
         alert.addButton(withTitle: L("RestartNow"))
         alert.addButton(withTitle: L("DiscardChange"))
-        
+
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
             // 立即重启应用


### PR DESCRIPTION
## Summary
- move `dlog` and `errorLog` into `Utils.swift`
- remove obsolete `Logging.swift`

Release logs remain at `~/Library/Logs/desktop-video.log`.

## Testing
- `swift --version`
- `swiftc 'desktop video/desktop video/SharedWallpaperWindowManager.swift' -o /tmp/test.o` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_6840fc511fbc8330969911319e61a4d1