### PR TITLE
feat: cancel screensaver when overlay covered

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,18 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.0 Beta hot-fix 2 (2025-06-18)
+
+- 添加全屏遮挡检测窗口，完全被遮挡时不进入屏保
+- Add full-screen overlay windows; cancel screensaver if fully covered
+
+### Version 3.0 Beta hot-fix 1 (2025-06-18)
+
+- 修复屏保启动时视频被误暂停的问题
+- 改进遮挡检测，避免随机暂停和恢复
+- Fix issue where videos paused when screensaver started
+- Improve occlusion handling to prevent random pauses
+
 ### Version 3.0 Beta (2025-06-11)
 
 - 更新闲置暂停逻辑，更智能，更节能


### PR DESCRIPTION
## Summary
- add full-screen overlay windows to check occlusion
- cancel entering screensaver if overlay fully covered
- record change in the changelog

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685225cc827c8330a299f5d18971b895