### PR TITLE
Implement stable screen UUID mapping

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.0 hot-fix 2 (2025-06-27)
+
+- 强绑定显示器 UUID，避免 PID 变化导致错绑
+- Use stable screen UUID to prevent window misalignment
+
 ### Version 3.0 hot-fix 1 (2025-06-27)
 
 - 修复新增或移除显示器后壁纸黑屏的问题

--- a/Desktop Video/desktop video/Utils.swift
+++ b/Desktop Video/desktop video/Utils.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import Foundation
+import CoreGraphics
 
 // MARK: - Notification 统一管理
 extension Notification.Name {
@@ -33,8 +34,23 @@ extension NSScreen {
         deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
     }
 
+    /// 稳定的屏幕标识，优先使用 CGDisplay 的 UUID
+    var dv_displayUUID: String {
+        if let id = dv_displayID,
+           let uuidRef = CGDisplayCreateUUIDFromDisplayID(id) {
+            let uuid = uuidRef.takeRetainedValue() as UUID
+            return uuid.uuidString
+        }
+        let res = "\(Int(frame.width))x\(Int(frame.height))"
+        return "\(dv_localizedName)-\(res)"
+    }
+
     static func screen(forDisplayID id: CGDirectDisplayID) -> NSScreen? {
         NSScreen.screens.first { $0.dv_displayID == id }
+    }
+
+    static func screen(forUUID uuid: String) -> NSScreen? {
+        NSScreen.screens.first { $0.dv_displayUUID == uuid }
     }
 }
 

--- a/desktop video/desktop video/ContentView.swift
+++ b/desktop video/desktop video/ContentView.swift
@@ -91,7 +91,7 @@ struct ContentView: View {
             if screenObserver.screens.count > 1 {
                 Button {
                     if let sourceScreen = selectedTabScreen,
-                       let id = sourceScreen.dv_displayID,
+                       let id = sourceScreen.dv_displayUUID,
                        let entry = SharedWallpaperWindowManager.shared.screenContent[id] {
 
                         if let fileType = UTType(filenameExtension: entry.url.pathExtension) {
@@ -231,10 +231,8 @@ struct SingleScreenView: View {
 
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                     let playerVolume: Float = {
-                                        if let id = screen.dv_displayID {
-                                            return SharedWallpaperWindowManager.shared.players[id]?.volume ?? newVolume
-                                        }
-                                        return newVolume
+                                        let id = screen.dv_displayUUID
+                                        return SharedWallpaperWindowManager.shared.players[id]?.volume ?? newVolume
                                     }()
                                     if abs(playerVolume - newVolume) > 0.01 {
 
@@ -311,8 +309,8 @@ struct SingleScreenView: View {
         .background(Color.gray.opacity(0.1))
         .cornerRadius(10)
         .onReceive(NotificationCenter.default.publisher(for: .wallpaperContentDidChange)) { _ in
-            if let id = screen.dv_displayID,
-               let entry = SharedWallpaperWindowManager.shared.screenContent[id] {
+            let id = screen.dv_displayUUID
+            if let entry = SharedWallpaperWindowManager.shared.screenContent[id] {
                 if currentEntry?.url != entry.url ||
                     currentEntry?.volume != entry.volume ||
                     currentEntry?.stretch != entry.stretch {
@@ -333,8 +331,8 @@ struct SingleScreenView: View {
         }
         .onAppear {
             dlog("SingleScreenView onAppear \(screen.dv_localizedName)")
-            if let id = screen.dv_displayID,
-               let entry = SharedWallpaperWindowManager.shared.screenContent[id] {
+            let id = screen.dv_displayUUID
+            if let entry = SharedWallpaperWindowManager.shared.screenContent[id] {
                 self.currentEntry = entry
                 self.volume = entry.volume ?? 1.0
                 self.stretchToFill = entry.stretch


### PR DESCRIPTION
## Summary
- bind wallpapers and players to NSScreen UUID instead of CGDirectDisplayID
- update screen helper utilities with `dv_displayUUID`
- adjust app logic to use UUID keys
- document the fix in the changelog

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e41a275c8833098467fe18430609f