### PR TITLE
Improve Chinese localization and comments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@
 - 修复沙盒环境下应用无法重启的问题
 - Moved idle pause sensitivity into AppState
 - Fixed restart logic for sandboxed environment
+- 增强中文翻译并添加更多中文注释
+- Improved Chinese localization and added detailed Chinese comments
 
 ### Version 3.1 (2025-06-28)
 

--- a/Desktop Video/desktop video/LanguageManager.swift
+++ b/Desktop Video/desktop video/LanguageManager.swift
@@ -33,11 +33,15 @@ enum SupportedLanguage: String, CaseIterable, Identifiable {
 
 /// 全局语言管理器
 class LanguageManager: ObservableObject {
+    /// 单例实例，方便在整个应用中调用
     static let shared = LanguageManager()
 
+    /// 当前用户选择的语言，`system` 表示跟随系统语言
     @AppStorage("selectedLanguage") var selectedLanguage: String = "system"
 
-    /// 返回当前语言的 Bundle（默认为 main）
+    /// 根据 `selectedLanguage` 返回对应的 `Bundle`
+    /// - 如果选择跟随系统，则直接返回 `Bundle.main`
+    /// - 如果指定了其它语言，则从 `.lproj` 目录构造 Bundle
     var bundle: Bundle {
         guard selectedLanguage != "system" else {
             return .main
@@ -50,13 +54,15 @@ class LanguageManager: ObservableObject {
         return .main
     }
 
-    /// 根据当前语言加载字符串
+    /// 根据当前语言获取本地化字符串
+    /// - Parameter key: 本地化键值
+    /// - Returns: 对应语言的字符串，若不存在则返回原键值
     func localizedString(forKey key: String) -> String {
         return bundle.localizedString(forKey: key, value: nil, table: nil)
     }
 }
 
-/// 语法糖辅助：本地化 key
+/// 语法糖：快速访问当前语言的本地化字符串
 func L(_ key: String) -> String {
     return LanguageManager.shared.localizedString(forKey: key)
 }

--- a/Desktop Video/desktop video/Localizable.xcstrings
+++ b/Desktop Video/desktop video/Localizable.xcstrings
@@ -94,7 +94,7 @@
       "zh-Hans" : {
         "stringUnit" : {
           "state" : "translated",
-          "value" : "启动屏保"
+          "value" : "启动屏幕保护程序"
         }
       },
       "zh-Hant" : {
@@ -1395,7 +1395,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开屏保"
+            "value" : "启动屏幕保护程序"
           }
         },
         "zh-Hant" : {

--- a/desktop video/desktop video/desktop_videoApp.swift
+++ b/desktop video/desktop video/desktop_videoApp.swift
@@ -13,6 +13,7 @@ import AppKit
 struct desktop_videoApp: App {
     static var shared: desktop_videoApp?
 
+    /// 缓存视频文件的最大大小限制（单位 GB）
     @AppStorage("maxVideoFileSizeInGB") var maxVideoFileSizeInGB: Double = 1.0
 
     // 关联 AppDelegate，所有"打开主窗口"或"打开偏好窗口"逻辑都在 AppDelegate 中处理
@@ -310,6 +311,7 @@ struct PreferencesView: View {
         }
     }
 
+    /// 重新启动应用以使新设置生效
     /// Relaunch the app so new preferences take effect.
     private func restartApplication() {
         dlog("restartApplication")


### PR DESCRIPTION
## Summary
- refine Chinese translation for the "Start Screensaver" menu item
- document LanguageManager and restart logic in Chinese
- document video size limit property in the app entry point
- expand the changelog with details of localization updates

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863910e72208330bfd107bf26b6eb45