### PR TITLE
feat: scaffold modern SwiftUI preference UI

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 2 (2025-08-14)
+
+- 引入现代化偏好窗口界面框架，基于 SwiftUI
+- 添加可扩展侧边栏与卡片式设置布局
+- Added SwiftUI-based preference window framework
+- Introduced extensible sidebar and card layout for settings
+
 ### Version 3.1 hot-fix 1 (2025-07-01)
 
 - 替换“自动暂停”开关为全新的播放模式选择

--- a/README_UI.md
+++ b/README_UI.md
@@ -1,0 +1,18 @@
+# UI Architecture
+
+This folder explains how to extend the SwiftUI based preference window.
+
+## Adding a new feature card
+
+1. Create a view model in `ViewModels/` (e.g. `NewFeatureVM`).
+2. Create a screen in `UI/Screens/` (e.g. `NewFeatureView`) that uses reusable components like `CardSection` and `FormRows`.
+3. Register a new case in `SidebarSelection` and provide a `SidebarItem` entry in `SidebarView`.
+4. Present the view in `AppMainWindow` switch statement.
+
+No changes to shared components are required.
+
+## Mapping from old controllers
+
+| Old Controller | New SwiftUI View |
+| --- | --- |
+| `ContentView` | `AppMainWindow` |

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import SwiftUI
+
+final class SnapshotTests: XCTestCase {
+    func testMainWindowPreview() {
+        let view = AppMainWindow().frame(width: 900, height: 600)
+        XCTAssertNotNil(view.body)
+    }
+}

--- a/Tests/ViewModelTests.swift
+++ b/Tests/ViewModelTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import desktop_video
+
+final class ViewModelTests: XCTestCase {
+    func testStartupDefaults() {
+        let vm = StartupDisplayVM()
+        XCTAssertFalse(vm.launchAtLogin)
+    }
+}

--- a/Theme/Theme.swift
+++ b/Theme/Theme.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// Global theme configuration.
+struct Theme {
+    /// Accent color pulled from App settings.
+    static var accentColor: Color {
+        Color.accentColor
+    }
+}

--- a/UI/AppMainWindow.swift
+++ b/UI/AppMainWindow.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct AppMainWindow: View {
+    @StateObject var appVM = AppViewModel()
+    var body: some View {
+        HStack(spacing: 0) {
+            SidebarView(selection: $appVM.selection)
+                .background(.regularMaterial)
+            ScrollView {
+                VStack(spacing: 16) {
+                    switch appVM.selection {
+                    case .startup:
+                        StartupDisplayView()
+                    case .custom:
+                        CustomControlsView()
+                    case .battery:
+                        BatteryChargingView()
+                    }
+                }
+                .padding(24)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct AppMainWindow_Previews: PreviewProvider {
+    static var previews: some View {
+        AppMainWindow()
+            .frame(width: 900, height: 600)
+    }
+}
+#endif

--- a/UI/Components/CardSection.swift
+++ b/UI/Components/CardSection.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct CardSection<Content: View>: View {
+    let titleKey: LocalizedStringKey
+    let systemImage: String
+    let helpKey: LocalizedStringKey?
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label(titleKey, systemImage: systemImage)
+                    .font(.headline)
+                Spacer()
+                if let helpKey {
+                    HelpButton(helpKey)
+                }
+            }
+            Divider()
+            content()
+        }
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+private struct HelpButton: View {
+    let key: LocalizedStringKey
+    @State private var show = false
+    var body: some View {
+        Button("?", action: { show.toggle() })
+            .accessibilityLabel(Text("help"))
+            .popover(isPresented: $show) {
+                Text(key)
+                    .padding()
+                    .frame(width: 200)
+            }
+    }
+    init(_ key: LocalizedStringKey) { self.key = key }
+}

--- a/UI/Components/FormRows.swift
+++ b/UI/Components/FormRows.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ToggleRow: View {
+    let titleKey: LocalizedStringKey
+    @Binding var value: Bool
+    var body: some View {
+        Toggle(titleKey, isOn: $value)
+    }
+}
+
+struct SliderRow: View {
+    let titleKey: LocalizedStringKey
+    @Binding var value: Double
+    var range: ClosedRange<Double>
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(titleKey)
+            Slider(value: $value, in: range)
+        }
+    }
+}
+
+struct StepperRow: View {
+    let titleKey: LocalizedStringKey
+    @Binding var value: Int
+    var body: some View {
+        Stepper(value: $value) {
+            Text(titleKey)
+        }
+    }
+}
+
+struct PickerRow<Content: View>: View {
+    let titleKey: LocalizedStringKey
+    @Binding var selection: Int
+    let content: Content
+    init(_ titleKey: LocalizedStringKey, selection: Binding<Int>, @ViewBuilder content: () -> Content) {
+        self.titleKey = titleKey
+        self._selection = selection
+        self.content = content()
+    }
+    var body: some View {
+        Picker(titleKey, selection: $selection) {
+            content
+        }
+    }
+}

--- a/UI/Components/MetricRow.swift
+++ b/UI/Components/MetricRow.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct MetricRow: View {
+    let titleKey: LocalizedStringKey
+    let value: String
+    let footnote: String?
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(titleKey)
+                Spacer()
+                Text(value)
+                    .foregroundStyle(.secondary)
+            }
+            if let footnote {
+                Text(footnote)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/UI/Screens/BatteryChargingView.swift
+++ b/UI/Screens/BatteryChargingView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct BatteryChargingView: View {
+    @StateObject var vm = BatteryChargingVM()
+    var body: some View {
+        CardSection(titleKey: "battery_charging", systemImage: "battery.100", helpKey: "battery_help") {
+            SliderRow(titleKey: "charge_limit", value: $vm.chargeLimit, range: 0...1)
+            MetricRow(titleKey: "current_capacity", value: vm.currentCapacity, footnote: nil)
+            MetricRow(titleKey: "design_capacity", value: vm.designCapacity, footnote: nil)
+        }
+    }
+}
+
+#if DEBUG
+struct BatteryChargingView_Previews: PreviewProvider {
+    static var previews: some View {
+        BatteryChargingView()
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/UI/Screens/CustomControlsView.swift
+++ b/UI/Screens/CustomControlsView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct CustomControlsView: View {
+    @StateObject var vm = CustomControlsVM()
+    var body: some View {
+        CardSection(titleKey: "custom_controls", systemImage: "slider.horizontal.3", helpKey: "custom_help") {
+            ToggleRow(titleKey: "thermal_protection", value: $vm.thermalProtection)
+            StepperRow(titleKey: "max_temperature", value: $vm.maxTemperature)
+            PickerRow("sleep_action", selection: $vm.sleepAction) {
+                Text("stop_charging").tag(0)
+                Text("keep_unchanged").tag(1)
+            }
+            PickerRow("exceed_action", selection: $vm.exceedAction) {
+                Text("stop_charging").tag(0)
+                Text("keep_unchanged").tag(1)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct CustomControlsView_Previews: PreviewProvider {
+    static var previews: some View {
+        CustomControlsView()
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/UI/Screens/StartupDisplayView.swift
+++ b/UI/Screens/StartupDisplayView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct StartupDisplayView: View {
+    @StateObject var vm = StartupDisplayVM()
+    var body: some View {
+        CardSection(titleKey: "startup_display", systemImage: "bolt.circle", helpKey: "startup_help") {
+            ToggleRow(titleKey: "launch_at_login", value: $vm.launchAtLogin)
+            PickerRow("language", selection: $vm.language.intBinding) {
+                Text("English").tag(0)
+                Text("中文").tag(1)
+            }
+            PickerRow("status_bar_style", selection: $vm.statusBarStyle) {
+                Text("battery").tag(0)
+                Text("battery_percent").tag(1)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct StartupDisplayView_Previews: PreviewProvider {
+    static var previews: some View {
+        StartupDisplayView()
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif
+
+private extension Binding where Value == String {
+    var intBinding: Binding<Int> {
+        Binding<Int>(
+            get: { Int(self.wrappedValue) ?? 0 },
+            set: { self.wrappedValue = String($0) }
+        )
+    }
+}

--- a/UI/Sidebar/SidebarItem.swift
+++ b/UI/Sidebar/SidebarItem.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct SidebarItem: View {
+    let icon: String
+    let nameKey: LocalizedStringKey
+    let selection: SidebarSelection
+    @Binding var current: SidebarSelection
+
+    var body: some View {
+        Button(action: { current = selection }) {
+            Label(nameKey, systemImage: icon)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(current == selection ? Color.accentColor.opacity(0.2) : .clear)
+        )
+    }
+}

--- a/UI/Sidebar/SidebarView.swift
+++ b/UI/Sidebar/SidebarView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @Binding var selection: SidebarSelection
+    var body: some View {
+        VStack(spacing: 16) {
+            VStack {
+                Image(systemName: "sparkles")
+                    .font(.largeTitle)
+                Text("v1.0")
+                    .font(.footnote)
+            }
+            .padding(.top, 24)
+            ForEach(SidebarSelection.allCases, id: \.self) { item in
+                switch item {
+                case .startup:
+                    SidebarItem(icon: "bolt.circle", nameKey: "startup_display", selection: item, current: $selection)
+                case .custom:
+                    SidebarItem(icon: "slider.horizontal.3", nameKey: "custom_controls", selection: item, current: $selection)
+                case .battery:
+                    SidebarItem(icon: "battery.100", nameKey: "battery_charging", selection: item, current: $selection)
+                }
+            }
+            Spacer()
+        }
+        .frame(width: 220)
+        .padding(.vertical, 24)
+    }
+}

--- a/ViewModels/AppViewModel.swift
+++ b/ViewModels/AppViewModel.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// Global application view model.
+final class AppViewModel: ObservableObject {
+    /// Currently selected sidebar item.
+    @Published var selection: SidebarSelection = .startup
+}
+
+/// Sidebar navigation items.
+enum SidebarSelection: Hashable, CaseIterable {
+    case startup
+    case custom
+    case battery
+}

--- a/ViewModels/BatteryChargingVM.swift
+++ b/ViewModels/BatteryChargingVM.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// View model for the Battery & Charging section.
+final class BatteryChargingVM: ObservableObject {
+    @AppStorage("chargeLimit") var chargeLimit: Double = 0.8
+    // Example read-only metrics; in real app these would come from system APIs.
+    @Published var currentCapacity: String = "--"
+    @Published var designCapacity: String = "--"
+}

--- a/ViewModels/CustomControlsVM.swift
+++ b/ViewModels/CustomControlsVM.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// View model for the Custom Controls section.
+final class CustomControlsVM: ObservableObject {
+    @AppStorage("thermalProtection") var thermalProtection: Bool = false
+    @AppStorage("maxTemperature") var maxTemperature: Int = 60
+    @AppStorage("sleepAction") var sleepAction: Int = 0
+    @AppStorage("exceedAction") var exceedAction: Int = 0
+}

--- a/ViewModels/StartupDisplayVM.swift
+++ b/ViewModels/StartupDisplayVM.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+/// View model for the Startup & Display section.
+final class StartupDisplayVM: ObservableObject {
+    @AppStorage("launchAtLogin") var launchAtLogin: Bool = false
+    @AppStorage("language") var language: String = "en"
+    @AppStorage("statusBarStyle") var statusBarStyle: Int = 0
+}


### PR DESCRIPTION
## Summary
- set up SwiftUI-based main window with sidebar and card sections
- introduce reusable components and view models for Startup, Custom, Battery screens
- document UI architecture and extend ChangeLog

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` (fails: command not found: xcodebuild)
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_689d7568e7848330b5310db80ca06a61