### PR TITLE
feat: refine preferences UI and enable wallpaper controls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,15 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 5 (2025-08-14)
+
+- 调整偏好设置窗口比例并居中文本
+- 替换侧边栏图标为应用 Logo
+- 新增选择、清除、播放与暂停壁纸的按钮
+- Refined preferences window layout and centered texts
+- Replaced sidebar emoji with the app logo
+- Added buttons to choose, clear, play and pause wallpapers
+
 ### Version 3.1 hot-fix 4 (2025-08-14)
 
 - 恢复 GitHub 文档文件到仓库根目录

--- a/Desktop Vdieo/Desktop Vdieo/ContentView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/ContentView.swift
@@ -5,7 +5,8 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         AppMainWindow()
-            .frame(minWidth: 820, minHeight: 520)
+            // Set a more balanced default window size
+            .frame(minWidth: 900, minHeight: 600)
     }
 }
 

--- a/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
+++ b/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
@@ -194,10 +194,96 @@
       }
     },
     "Choose Video…" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Video…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择视频或图片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇影片或圖片"
+          }
+        }
+      }
     },
     "Clear" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
+        }
+      }
+    },
+    "Play" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放"
+          }
+        }
+      }
+    },
+    "Pause" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停"
+          }
+        }
+      }
     },
     "CloseWallpaper" : {
       "extractionState" : "manual",

--- a/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
@@ -8,13 +8,13 @@ struct AppMainWindow: View {
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $vm.selection)
-                .frame(minWidth: 150, maxWidth: 200)
+                .frame(width: 220)
                 .background(.ultraThinMaterial)
 
             Divider()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .center, spacing: 16) {
                     switch vm.selection {
                     case .wallpaper: WallpaperView()
                     case .playback: PlaybackSettingsView()

--- a/Desktop Vdieo/Desktop Vdieo/UI/Components/CardSection.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Components/CardSection.swift
@@ -9,6 +9,7 @@ struct CardSection<Content: View>: View {
     var body: some View {
         VStack(alignment: .center, spacing: 12) {
             HStack {
+                Spacer()
                 Label(title, systemImage: systemImage)
                     .font(.headline)
                 Spacer()

--- a/Desktop Vdieo/Desktop Vdieo/UI/Components/FormRows.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Components/FormRows.swift
@@ -4,7 +4,10 @@ import SwiftUI
 struct ToggleRow: View {
     let title: LocalizedStringKey
     @Binding var value: Bool
-    var body: some View { Toggle(title, isOn: $value) }
+    var body: some View {
+        Toggle(title, isOn: $value)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
 }
 
 struct SliderRow: View {
@@ -16,6 +19,7 @@ struct SliderRow: View {
             Text(title)
             Slider(value: $value, in: range)
         }
+        .frame(maxWidth: .infinity)
     }
 }
 
@@ -24,6 +28,7 @@ struct StepperRow: View {
     @Binding var value: Int
     var body: some View {
         Stepper(value: $value) { Text(title) }
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 
@@ -36,5 +41,8 @@ struct PickerRow<Content: View>: View {
         self._selection = selection
         self.content = content()
     }
-    var body: some View { Picker(title, selection: $selection) { content } }
+    var body: some View {
+        Picker(title, selection: $selection) { content }
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
 }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
@@ -1,18 +1,82 @@
-
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
-/// Placeholder - wire this up to your actual wallpaper window manager.
+/// Controls for a single screen's wallpaper.
 struct SingleScreenView: View {
+    let screen: NSScreen
     @State private var volume: Double = 1.0
     @State private var stretchToFill: Bool = true
+    
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Button("Choose Video…") { /* open panel */ }
-                Button("Clear") { /* clear */ }
+        VStack(alignment: .center, spacing: 12) {
+            HStack(spacing: 8) {
+                Button("Choose Video…", action: chooseMedia)
+                Button("Clear", action: clear)
+                Button("Play", action: play)
+                Button("Pause", action: pause)
             }
             SliderRow(title: "Volume", value: $volume, range: 0...1)
+                .onChange(of: volume) { newValue in
+                    let sid = screen.dv_displayUUID
+                    SharedWallpaperWindowManager.shared.players[sid]?.volume = Float(newValue)
+                    dlog("set volume \(newValue) for \(screen.dv_localizedName)")
+                }
             ToggleRow(title: "Stretch to fill", value: $stretchToFill)
+                .onChange(of: stretchToFill) { newValue in
+                    updateStretch(newValue)
+                }
         }
+    }
+    
+    // 打开媒体选择面板并设置壁纸
+    private func chooseMedia() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.movie, .video, .image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url {
+            dlog("chooseMedia url=\(url.lastPathComponent)")
+            if let type = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType {
+                if type.conforms(to: .image) {
+                    SharedWallpaperWindowManager.shared.showImage(for: screen, url: url, stretch: stretchToFill)
+                } else {
+                    SharedWallpaperWindowManager.shared.showVideo(for: screen, url: url, stretch: stretchToFill, volume: Float(volume))
+                }
+            }
+        }
+    }
+    
+    // 清除当前屏幕的壁纸
+    private func clear() {
+        dlog("clear wallpaper for \(screen.dv_localizedName)")
+        SharedWallpaperWindowManager.shared.clear(for: screen)
+    }
+    
+    // 播放当前屏幕的壁纸
+    private func play() {
+        let sid = screen.dv_displayUUID
+        dlog("play wallpaper for \(screen.dv_localizedName)")
+        SharedWallpaperWindowManager.shared.players[sid]?.play()
+    }
+    
+    // 暂停当前屏幕的壁纸
+    private func pause() {
+        let sid = screen.dv_displayUUID
+        dlog("pause wallpaper for \(screen.dv_localizedName)")
+        SharedWallpaperWindowManager.shared.players[sid]?.pause()
+    }
+    
+    private func updateStretch(_ stretch: Bool) {
+        let sid = screen.dv_displayUUID
+        if let entry = SharedWallpaperWindowManager.shared.screenContent[sid] {
+            switch entry.type {
+            case .image:
+                SharedWallpaperWindowManager.shared.showImage(for: screen, url: entry.url, stretch: stretch)
+            case .video:
+                SharedWallpaperWindowManager.shared.showVideo(for: screen, url: entry.url, stretch: stretch, volume: Float(volume))
+            }
+        }
+        dlog("update stretch \(stretch) for \(screen.dv_localizedName)")
     }
 }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
@@ -1,11 +1,14 @@
 
 import SwiftUI
+import AppKit
 
 struct WallpaperView: View {
     @State private var menuBarOnly = UserDefaults.standard.bool(forKey: "isMenuBarOnly")
     var body: some View {
         CardSection(title: "Wallpaper", systemImage: "sparkles", help: "Manage video wallpapers per display.") {
-            SingleScreenView()
+            ForEach(NSScreen.screens, id: \.dv_displayUUID) { screen in
+                SingleScreenView(screen: screen)
+            }
             ToggleRow(title: "Show only in menu bar", value: Binding(
                 get: { menuBarOnly },
                 set: { UserDefaults.standard.set($0, forKey: "isMenuBarOnly"); menuBarOnly = $0 }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarItem.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarItem.swift
@@ -11,7 +11,8 @@ struct SidebarItem: View {
         Button(action: { current = selection }) {
             Label(name, systemImage: icon)
                 .padding(.vertical, 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
         }
         .buttonStyle(.plain)
         .padding(.horizontal)

--- a/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarView.swift
@@ -1,16 +1,20 @@
 
 import SwiftUI
+import AppKit
 
 struct SidebarView: View {
     @Binding var selection: SidebarSelection
     var body: some View {
         VStack(spacing: 8) {
             VStack {
-                Image(systemName: "play.rectangle.on.rectangle")
-                    .font(.largeTitle)
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 48, height: 48)
                 Text("Desktop Video")
                     .font(.footnote)
-            }.padding(.top, 8)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 8)
 
             ForEach(SidebarSelection.allCases, id: \.self) { item in
                 switch item {


### PR DESCRIPTION
## Summary
- improve window proportions and center text throughout the preferences UI
- replace sidebar emoji with the app logo
- add working controls for choosing, clearing, playing and pausing wallpapers

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9b9a627483309e2adf571827fa6b