### PR TITLE
feat: make main window sidebar resizable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 6 (2025-08-22)
+
+- 使主控制界面分割线可拖动调整左右宽度
+- Added draggable divider to resize sidebar and content areas
+
 ### Version 3.1 hot-fix 5 (2025-08-14)
 
 - 调整偏好设置窗口比例并居中文本

--- a/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
@@ -4,14 +4,30 @@ import SwiftUI
 /// Main window using a sidebar + card content layout.
 struct AppMainWindow: View {
     @StateObject private var vm = AppViewModel()
+    @State private var sidebarWidth: CGFloat = 220
+    @State private var dragStartWidth: CGFloat = 220
+    private let minSidebarWidth: CGFloat = 160
+    private let maxSidebarWidth: CGFloat = 400
 
     var body: some View {
         HStack(spacing: 0) {
             SidebarView(selection: $vm.selection)
-                .frame(width: 220)
+                .frame(width: sidebarWidth)
                 .background(.ultraThinMaterial)
 
             Divider()
+                .padding(.horizontal, 2)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            let proposed = dragStartWidth + value.translation.width
+                            updateSidebarWidth(proposed)
+                        }
+                        .onEnded { _ in
+                            dragStartWidth = sidebarWidth
+                        }
+                )
 
             ScrollView {
                 VStack(alignment: .center, spacing: 16) {
@@ -23,6 +39,14 @@ struct AppMainWindow: View {
                 }
                 .padding(20)
             }
+        }
+    }
+
+    private func updateSidebarWidth(_ newWidth: CGFloat) {
+        let clamped = min(max(newWidth, minSidebarWidth), maxSidebarWidth)
+        if clamped != sidebarWidth {
+            dlog("Sidebar width adjusted to \(clamped)")
+            sidebarWidth = clamped
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow dragging the divider to resize the sidebar and content
- document resizable sidebar behavior in changelog

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b3958bb483309a84b1f0c78ffec5