### PR TITLE
fix: stabilize multi-screen controls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,15 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 6 (2025-09-01)
+
+- 改善多显示器列表更新逻辑
+- 移除调试遮挡窗口以避免桌面切换闪烁
+- 修复控制面板初始状态不同步的问题
+- Improve multi-display list refresh
+- Remove debug overlay to prevent flashes when switching desktops
+- Sync initial control values in the settings page
+
 ### Version 3.1 hot-fix 5 (2025-08-14)
 
 - 调整偏好设置窗口比例并居中文本

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 7 (2025-09-02)
+
+- 修复“仅在菜单栏显示”选项未立即生效的问题
+- Fix issue where "Show only in menu bar" didn't apply immediately
+
 ### Version 3.1 hot-fix 6 (2025-09-01)
 
 - 改善多显示器列表更新逻辑

--- a/Desktop Vdieo/Desktop Vdieo/SharedWallpaperWindowManager.swift
+++ b/Desktop Vdieo/Desktop Vdieo/SharedWallpaperWindowManager.swift
@@ -248,10 +248,7 @@ class SharedWallpaperWindowManager {
         // overlay 必须高于 screensaverOverlay，但仍低于普通窗口
         overlay.level = NSWindow.Level(Int(CGWindowLevelForKey(.desktopWindow))) + 2
         overlay.isOpaque = false
-//        overlay.backgroundColor = .clear   // keep fully transparent for occlusion checks
-        // To debug overlay position, uncomment next two lines:
-         overlay.backgroundColor = .white
-         dlog("Debug Feature On!")
+        overlay.backgroundColor = .clear   // keep fully transparent for occlusion checks
         overlay.ignoresMouseEvents = true
         overlay.alphaValue = 0.0001   // barely visible but participates in occlusion
         overlay.collectionBehavior = [.canJoinAllSpaces, .stationary]

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
@@ -27,8 +27,9 @@ struct SingleScreenView: View {
                     updateStretch(newValue)
                 }
         }
+        .onAppear(perform: syncInitialState)
     }
-    
+
     // 打开媒体选择面板并设置壁纸
     private func chooseMedia() {
         let panel = NSOpenPanel()
@@ -66,7 +67,7 @@ struct SingleScreenView: View {
         dlog("pause wallpaper for \(screen.dv_localizedName)")
         SharedWallpaperWindowManager.shared.players[sid]?.pause()
     }
-    
+
     private func updateStretch(_ stretch: Bool) {
         let sid = screen.dv_displayUUID
         if let entry = SharedWallpaperWindowManager.shared.screenContent[sid] {
@@ -78,5 +79,16 @@ struct SingleScreenView: View {
             }
         }
         dlog("update stretch \(stretch) for \(screen.dv_localizedName)")
+    }
+
+    private func syncInitialState() {
+        let sid = screen.dv_displayUUID
+        if let player = SharedWallpaperWindowManager.shared.players[sid] {
+            volume = Double(player.volume)
+        }
+        if let entry = SharedWallpaperWindowManager.shared.screenContent[sid] {
+            stretchToFill = entry.stretch
+        }
+        dlog("sync controls for \(screen.dv_localizedName)")
     }
 }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
@@ -3,10 +3,11 @@ import SwiftUI
 import AppKit
 
 struct WallpaperView: View {
+    @StateObject private var screenObserver = ScreenObserver()
     @State private var menuBarOnly = UserDefaults.standard.bool(forKey: "isMenuBarOnly")
     var body: some View {
         CardSection(title: "Wallpaper", systemImage: "sparkles", help: "Manage video wallpapers per display.") {
-            ForEach(NSScreen.screens, id: \.dv_displayUUID) { screen in
+            ForEach(screenObserver.screens, id: \.dv_displayUUID) { screen in
                 SingleScreenView(screen: screen)
             }
             ToggleRow(title: "Show only in menu bar", value: Binding(

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
@@ -12,7 +12,10 @@ struct WallpaperView: View {
             }
             ToggleRow(title: "Show only in menu bar", value: Binding(
                 get: { menuBarOnly },
-                set: { UserDefaults.standard.set($0, forKey: "isMenuBarOnly"); menuBarOnly = $0 }
+                set: {
+                    menuBarOnly = $0
+                    AppDelegate.shared.setDockIconVisible(!$0)
+                }
             ))
         }
     }


### PR DESCRIPTION
## Summary
- refresh wallpaper screen list on display changes
- remove debug overlay causing flash
- sync control values with active wallpaper settings

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b632b953548330b6e599f62e7cbd83