### PR TITLE
feat: add playback mode descriptions and volume controls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,22 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 9 (2025-09-02)
+
+- 为播放模式提供详细说明
+- Add descriptions for playback modes
+- 新增音量与空闲暂停灵敏度输入框并追加静音复选框
+- Add input fields for volume and idle-pause sensitivity with a mute checkbox
+
+### Version 3.1 hot-fix 8 (2025-09-02)
+
+- 修复语言选择器未正确显示所选语言的问题
+- Fix language picker not showing the selected language
+- 新增繁體中文、法语和西班牙语等语言选项
+- Add language options for Traditional Chinese, French, and Spanish
+- 缩小偏好设置窗口尺寸以更好匹配字体大小
+- Reduce preferences window size to better match the font size
+
 ### Version 3.1 hot-fix 7 (2025-09-02)
 
 - 修复“仅在菜单栏显示”选项未立即生效的问题

--- a/Desktop Vdieo/Desktop Vdieo/ContentView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/ContentView.swift
@@ -5,8 +5,8 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         AppMainWindow()
-            // Set a more balanced default window size
-            .frame(minWidth: 900, minHeight: 600)
+            // Set a more balanced default window size (about 30% smaller)
+            .frame(minWidth: 630, minHeight: 420)
     }
 }
 

--- a/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
+++ b/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
@@ -1021,6 +1021,76 @@
         }
       }
     },
+    "PlaybackStatic" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pause" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pausar" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pause" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "暂停" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "暫停" } }
+      }
+    },
+    "PlaybackAlwaysDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Always play video regardless of activity." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Reproduce siempre el video sin importar la actividad." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Lit toujours la vidéo quelle que soit l'activité." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "始终播放，不受活动影响。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "始終播放，不受活動影響。" } }
+      }
+    },
+    "PlaybackAutoDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pause when the system is idle." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pausa cuando el sistema está inactivo." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Met en pause lorsque le système est inactif." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "空闲时暂停播放。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "閒置時暫停播放。" } }
+      }
+    },
+    "PlaybackPowerSaveDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pause when the screen is fully covered." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pausa cuando la pantalla está completamente cubierta." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Met en pause lorsque l'écran est entièrement couvert." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "完全遮挡时暂停。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "完全遮擋時暫停。" } }
+      }
+    },
+    "PlaybackPowerSavePlusDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pause when any part of the screen is covered." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Pausa cuando cualquier parte de la pantalla está cubierta." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Met en pause lorsqu'une partie de l'écran est couverte." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "任意遮挡时暂停。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "任意遮擋時暫停。" } }
+      }
+    },
+    "PlaybackStaticDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Do not play the video." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "No reproducir el video." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ne pas lire la vidéo." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "不播放视频。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "不播放視頻。" } }
+      }
+    },
+    "MuteVideo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mute Video" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Silenciar video" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Couper le son de la vidéo" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "静音视频" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "靜音視頻" } }
+      }
+    },
     "Preferences" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
@@ -27,14 +27,14 @@ struct GeneralSettingsView: View {
                 }
             ))
             HStack {
-                Text("Language")
+                Text(L("Language"))
                 Picker("", selection: $language) {
-                    Text("System").tag("system")
-                    Text("English").tag("en")
-                    Text("中文").tag("zh")
+                    ForEach(SupportedLanguage.allCases) { lang in
+                        Text(lang.displayName).tag(lang.rawValue)
+                    }
                 }
                 .pickerStyle(.menu)
-                .frame(width: 120)
+                .frame(width: 150)
                 .labelsHidden()
             }
             HStack {

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/PlaybackSettingsView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/PlaybackSettingsView.swift
@@ -1,13 +1,23 @@
 
 import SwiftUI
+import AppKit
 
 struct PlaybackSettingsView: View {
     @ObservedObject private var appState = AppState.shared
+    @AppStorage("globalVolume") private var globalVolume: Double = 100
+    @AppStorage("globalMute") private var globalMute: Bool = false
+
+    private let numberFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.minimum = 0
+        f.maximum = 100
+        return f
+    }()
 
     var body: some View {
         CardSection(title: "Playback", systemImage: "bolt.circle", help: "Auto pause and power modes.") {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Mode").font(.subheadline)
+                Text(L("PlaybackMode")).font(.subheadline)
                 Picker("", selection: Binding(
                     get: { appState.playbackMode.rawValue },
                     set: { appState.playbackMode = AppState.PlaybackMode(rawValue: $0) ?? .automatic }
@@ -18,7 +28,40 @@ struct PlaybackSettingsView: View {
                 }
                 .labelsHidden()
 
-                SliderRow(title: "Idle pause sensitivity", value: $appState.idlePauseSensitivity, range: 0...100)
+                Text(appState.playbackMode.detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Text(L("Volume"))
+                    TextField("100", value: $globalVolume, formatter: numberFormatter)
+                        .frame(width: 40)
+                    Text("%")
+                    Toggle(L("MuteVideo"), isOn: $globalMute)
+                }
+                .onChange(of: globalVolume) { newValue in
+                    let clamped = min(max(newValue, 0), 100)
+                    globalVolume = clamped
+                    dlog("set global volume \(clamped)")
+                    for screen in NSScreen.screens {
+                        SharedWallpaperWindowManager.shared.setVolume(Float(clamped / 100.0), for: screen)
+                    }
+                }
+                .onChange(of: globalMute) { newValue in
+                    dlog("apply global mute \(newValue)")
+                    desktop_videoApp.applyGlobalMute(newValue)
+                }
+
+                HStack {
+                    Text(L("idlePauseSensitivity"))
+                    TextField("0", value: $appState.idlePauseSensitivity, formatter: numberFormatter)
+                        .frame(width: 40)
+                }
+                .onChange(of: appState.idlePauseSensitivity) { newValue in
+                    let clamped = min(max(newValue, 0), 100)
+                    appState.idlePauseSensitivity = clamped
+                    dlog("set idle pause sensitivity \(clamped)")
+                }
             }
         }
     }

--- a/Desktop Vdieo/Desktop Vdieo/ViewModels/AppState.swift
+++ b/Desktop Vdieo/Desktop Vdieo/ViewModels/AppState.swift
@@ -37,6 +37,17 @@ class AppState: ObservableObject {
             case .stationary: return L("PlaybackStatic")
             }
         }
+
+        /// Detailed description for UI display
+        var detail: String {
+            switch self {
+            case .alwaysPlay:    return L("PlaybackAlwaysDesc")
+            case .automatic:     return L("PlaybackAutoDesc")
+            case .powerSave:     return L("PlaybackPowerSaveDesc")
+            case .powerSavePlus: return L("PlaybackPowerSavePlusDesc")
+            case .stationary:    return L("PlaybackStaticDesc")
+            }
+        }
     }
 
     /// 用户选定的播放模式（默认 automatic）；写入 UserDefaults 以便持久化


### PR DESCRIPTION
## Summary
- describe playback modes in settings
- add volume and idle-pause inputs with mute option
- update localization and changelog

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6395af884833095dc672464f17d1e