### PR TITLE
fix: localize UI strings and restore about dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0902 hot-fix 1 (2025-09-02)
+
+- 本地化单屏幕与设置页面字符串
+- 恢复关于对话框原始内容
+- Localize single-screen and settings page strings
+- Restore original About dialog text
+
 ### Version 4.0 Preview 0902 (2025-09-02)
 
 - 为主控制器侧边栏添加本地化支持

--- a/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
+++ b/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
@@ -61,10 +61,44 @@
       }
     },
     "Auto pause and power modes." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : { "state" : "translated", "value" : "Auto pause and power modes." }
+        },
+        "es" : {
+          "stringUnit" : { "state" : "translated", "value" : "Pausa automática y modos de energía." }
+        },
+        "fr" : {
+          "stringUnit" : { "state" : "translated", "value" : "Pause automatique et modes d'énergie." }
+        },
+        "zh-Hans" : {
+          "stringUnit" : { "state" : "translated", "value" : "自动暂停和电源模式。" }
+        },
+        "zh-Hant" : {
+          "stringUnit" : { "state" : "translated", "value" : "自動暫停和電源模式。" }
+        }
+      }
     },
     "Auto sync new screens" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : { "state" : "translated", "value" : "Auto sync new screens" }
+        },
+        "es" : {
+          "stringUnit" : { "state" : "translated", "value" : "Sincronizar pantallas nuevas automáticamente" }
+        },
+        "fr" : {
+          "stringUnit" : { "state" : "translated", "value" : "Synchroniser automatiquement les nouveaux écrans" }
+        },
+        "zh-Hans" : {
+          "stringUnit" : { "state" : "translated", "value" : "自动同步新插入的显示器" }
+        },
+        "zh-Hant" : {
+          "stringUnit" : { "state" : "translated", "value" : "自動同步新插入的顯示器" }
+        }
+      }
     },
     "AutoSyncNewScreens" : {
       "extractionState" : "manual",
@@ -242,7 +276,14 @@
       }
     },
     "Common preferences." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Common preferences." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Preferencias comunes." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Préférences générales." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "通用偏好设置。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "通用偏好設定。" } }
+      }
     },
     "Confirm" : {
       "extractionState" : "manual",
@@ -528,7 +569,14 @@
       }
     },
     "help" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "help" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "ayuda" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "aide" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "帮助" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "幫助" } }
+      }
     },
     "idlePauseSensitivity" : {
       "extractionState" : "manual",
@@ -601,7 +649,14 @@
       }
     },
     "Launch at login" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Launch at login" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Iniciar al iniciar sesión" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Lancer à l'ouverture de session" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "登录时启动" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "登入時啟動" } }
+      }
     },
     "LaunchAtLogin" : {
       "extractionState" : "manual",
@@ -674,10 +729,24 @@
       }
     },
     "Manage video wallpapers per display." : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Manage video wallpapers per display." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Gestiona fondos de video por pantalla." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Gérer les fonds d'écran vidéo par écran." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "按显示器管理视频壁纸。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "按顯示器管理影片桌布。" } }
+      }
     },
     "Max video cache (GB)" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Max video cache (GB)" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Caché de video máxima (GB)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Cache vidéo max (Go)" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "视频缓存上限（GB）" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "影片快取上限（GB）" } }
+      }
     },
     "MaxVideoFileSizeGB" : {
       "extractionState" : "manual",
@@ -1730,7 +1799,14 @@
       }
     },
     "Show only in menu bar" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show only in menu bar" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Mostrar solo en la barra de menús" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Afficher uniquement dans la barre de menus" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "仅在菜单栏显示" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "僅在選單列顯示" } }
+      }
     },
     "StartScreensaver" : {
       "extractionState" : "manual",
@@ -1905,6 +1981,16 @@
             "value" : "同步當前螢幕狀態到所有螢幕"
           }
         }
+      }
+    },
+    "Unknown" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unknown" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Desconocido" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Inconnu" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未知" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "未知" } }
       }
     },
     "UnknownScreen" : {

--- a/Desktop Vdieo/Desktop Vdieo/UI/Components/CardSection.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Components/CardSection.swift
@@ -36,7 +36,7 @@ private struct HelpButton: View {
     @State private var show = false
     var body: some View {
         Button("?") { show.toggle() }
-            .accessibilityLabel(Text("help"))
+            .accessibilityLabel(Text(L("help")))
             .popover(isPresented: $show) { Text(key).padding().frame(width: 200) }
     }
     init(_ key: LocalizedStringKey) { self.key = key }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
@@ -16,8 +16,8 @@ struct GeneralSettingsView: View {
     @State private var isReverting = false
 
     var body: some View {
-        CardSection(title: "General", systemImage: "gearshape", help: "Common preferences.") {
-            ToggleRow(title: "Auto sync new screens", value: $autoSyncNewScreens)
+        CardSection(title: L("General"), systemImage: "gearshape", help: L("Common preferences.")) {
+            ToggleRow(title: L("Auto sync new screens"), value: $autoSyncNewScreens)
                 .onChange(of: autoSyncNewScreens) { newValue in
                     guard !isReverting else { isReverting = false; return }
                     dlog("autoSyncNewScreens changed to \(newValue), restart required")
@@ -29,7 +29,7 @@ struct GeneralSettingsView: View {
                         autoSyncNewScreens = previous
                     }
                 }
-            ToggleRow(title: "Launch at login", value: Binding(
+            ToggleRow(title: L("Launch at login"), value: Binding(
                 get: { launchAtLogin },
                 set: {
                     launchAtLogin = $0
@@ -87,7 +87,7 @@ struct GeneralSettingsView: View {
                 }
             }
             HStack {
-                Text("Max video cache (GB)")
+                Text(L("Max video cache (GB)"))
                 TextField("1.0", value: $maxVideoFileSizeInGB, formatter: NumberFormatter())
                     .frame(width: 60)
                     .onChange(of: maxVideoFileSizeInGB) { newValue in

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/PlaybackSettingsView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/PlaybackSettingsView.swift
@@ -15,7 +15,7 @@ struct PlaybackSettingsView: View {
     }()
 
     var body: some View {
-        CardSection(title: "Playback", systemImage: "bolt.circle", help: "Auto pause and power modes.") {
+        CardSection(title: L("Playback"), systemImage: "bolt.circle", help: L("Auto pause and power modes.")) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(L("PlaybackMode")).font(.subheadline)
                 Picker("", selection: Binding(

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/SingleScreenView.swift
@@ -11,12 +11,12 @@ struct SingleScreenView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 12) {
             HStack(spacing: 8) {
-                Button("Choose Video…", action: chooseMedia)
-                Button("Clear", action: clear)
-                Button("Play", action: play)
-                Button("Pause", action: pause)
+                Button(L("Choose Video…"), action: chooseMedia)
+                Button(L("Clear"), action: clear)
+                Button(L("Play"), action: play)
+                Button(L("Pause"), action: pause)
             }
-            SliderInputRow(title: "Volume", value: $volume, range: 0...100)
+            SliderInputRow(title: L("Volume"), value: $volume, range: 0...100)
                 .onChange(of: volume) { newValue in
                     let clamped = min(max(newValue, 0), 100)
                     volume = clamped
@@ -24,7 +24,7 @@ struct SingleScreenView: View {
                     SharedWallpaperWindowManager.shared.players[sid]?.volume = Float(clamped / 100.0)
                     dlog("set volume \(clamped) for \(screen.dv_localizedName)")
                 }
-            ToggleRow(title: "Stretch to fill", value: $stretchToFill)
+            ToggleRow(title: L("Stretch to fill"), value: $stretchToFill)
                 .onChange(of: stretchToFill) { newValue in
                     updateStretch(newValue)
                 }

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/WallpaperView.swift
@@ -6,11 +6,11 @@ struct WallpaperView: View {
     @StateObject private var screenObserver = ScreenObserver()
     @State private var menuBarOnly = UserDefaults.standard.bool(forKey: "isMenuBarOnly")
     var body: some View {
-        CardSection(title: "Wallpaper", systemImage: "sparkles", help: "Manage video wallpapers per display.") {
+        CardSection(title: L("Wallpaper"), systemImage: "sparkles", help: L("Manage video wallpapers per display.")) {
             ForEach(screenObserver.screens, id: \.dv_displayUUID) { screen in
                 SingleScreenView(screen: screen)
             }
-            ToggleRow(title: "Show only in menu bar", value: Binding(
+            ToggleRow(title: L("Show only in menu bar"), value: Binding(
                 get: { menuBarOnly },
                 set: {
                     menuBarOnly = $0


### PR DESCRIPTION
## Summary
- restore original About dialog text
- localize single-screen controls and settings views
- clean up unused About dialog translation key

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b72d615eac83309ecbd8b48ef2b8a6