### PR TITLE
feat: sync preference settings to general

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0903 hot-fix 1 (2025-09-03)
+
+- 同步偏好设置到通用设置界面
+- Copy preference settings into general UI
+
 ### Version 4.0 Preview 0903 (2025-09-03)
 
 - 在多屏幕环境中添加选择框以指定连接的显示器

--- a/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Screens/GeneralSettingsView.swift
@@ -7,16 +7,28 @@ struct GeneralSettingsView: View {
     @AppStorage("launchAtLogin")     private var launchAtLogin:     Bool = true
     @AppStorage("selectedLanguage")  private var language:          String = "system"
     @AppStorage("maxVideoFileSizeInGB") private var maxVideoFileSizeInGB: Double = 1.0
+    @AppStorage("globalMute") private var globalMute: Bool = false
+    @AppStorage("screensaverEnabled") private var screensaverEnabled: Bool = false
+    @AppStorage("screensaverDelayMinutes") private var screensaverDelayMinutes: Double = 5.0
+
+    @ObservedObject private var appState = AppState.shared
 
     @State private var originalAutoSyncNewScreens = UserDefaults.standard.bool(forKey: "autoSyncNewScreens")
     @State private var originalLaunchAtLogin = UserDefaults.standard.bool(forKey: "launchAtLogin")
     @State private var originalLanguage = UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system"
     @State private var originalMaxVideoFileSizeInGB = UserDefaults.standard.double(forKey: "maxVideoFileSizeInGB")
+    @State private var originalScreensaverEnabled = UserDefaults.standard.bool(forKey: "screensaverEnabled")
+    @State private var originalScreensaverDelayMinutes = UserDefaults.standard.double(forKey: "screensaverDelayMinutes")
 
     @State private var isReverting = false
 
     var body: some View {
         CardSection(title: LocalizedStringKey(L("General")), systemImage: "gearshape", help: LocalizedStringKey(L("Common preferences."))) {
+            ToggleRow(title: LocalizedStringKey(L("GlobalMute")), value: $globalMute)
+                .onChange(of: globalMute) { newValue in
+                    desktop_videoApp.applyGlobalMute(newValue)
+                }
+
             ToggleRow(title: LocalizedStringKey(L("Auto sync new screens")), value: $autoSyncNewScreens)
                 .onChange(of: autoSyncNewScreens) { newValue in
                     guard !isReverting else { isReverting = false; return }
@@ -86,6 +98,67 @@ struct GeneralSettingsView: View {
                     language = previous
                 }
             }
+
+            ToggleRow(title: LocalizedStringKey(L("EnableScreenSaver")), value: $screensaverEnabled)
+                .onChange(of: screensaverEnabled) { newValue in
+                    guard !isReverting else { isReverting = false; return }
+                    dlog("screensaverEnabled changed to \(newValue), restart required")
+                    let previous = originalScreensaverEnabled
+                    desktop_videoApp.showRestartAlert {
+                        originalScreensaverEnabled = newValue
+                    } onDiscard: {
+                        isReverting = true
+                        screensaverEnabled = previous
+                    }
+                }
+
+            HStack {
+                Text(L("ScreenSaverDelay"))
+                TextField("5", value: $screensaverDelayMinutes, formatter: NumberFormatter())
+                    .frame(width: 30)
+                Text(L("MinutetoSaver"))
+            }
+            .disabled(!screensaverEnabled)
+            .onChange(of: screensaverDelayMinutes) { newValue in
+                guard !isReverting else { isReverting = false; return }
+                dlog("screensaverDelayMinutes changed to \(newValue), restart required")
+                let previous = originalScreensaverDelayMinutes
+                desktop_videoApp.showRestartAlert {
+                    originalScreensaverDelayMinutes = newValue
+                } onDiscard: {
+                    isReverting = true
+                    screensaverDelayMinutes = previous
+                }
+            }
+
+            VStack {
+                Text(L("PlaybackMode")).font(.subheadline)
+                Picker("", selection: Binding(
+                    get: { appState.playbackMode.rawValue },
+                    set: { appState.playbackMode = AppState.PlaybackMode(rawValue: $0) ?? .automatic }
+                )) {
+                    ForEach(AppState.PlaybackMode.allCases, id: \.rawValue) { mode in
+                        Text(mode.description).tag(mode.rawValue)
+                    }
+                }
+                .labelsHidden()
+                Text(appState.playbackMode.detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 10)
+            .onChange(of: appState.playbackMode) { newValue in
+                dlog("playbackMode changed to \(newValue)")
+                AppDelegate.shared?.updatePlaybackStateForAllScreens()
+            }
+
+            SliderInputRow(title: LocalizedStringKey(L("idlePauseSensitivity")), value: $appState.idlePauseSensitivity, range: 0...100)
+                .onChange(of: appState.idlePauseSensitivity) { newValue in
+                    let clamped = min(max(newValue, 0), 100)
+                    appState.idlePauseSensitivity = clamped
+                    dlog("set idle pause sensitivity \(clamped)")
+                }
+
             HStack {
                 Text(L("Max video cache (GB)"))
                 TextField("1.0", value: $maxVideoFileSizeInGB, formatter: NumberFormatter())


### PR DESCRIPTION
## Summary
- integrate all preference options into general settings UI, including global mute, screensaver, playback mode, and idle pause sensitivity
- document the settings sync in the changelog

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b8831c8e208330b40d2ab7b6314696