### PR TITLE
feat: scale UI with window size

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 
 - 同步偏好设置到通用设置界面
 - Copy preference settings into general UI
+- 主窗口尺寸增大时同步放大文本和图标
+- Scale text and icons when enlarging main window
 
 ### Version 4.0 Preview 0903 (2025-09-03)
 

--- a/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/AppMainWindow.swift
@@ -4,25 +4,35 @@ import SwiftUI
 /// Main window using a sidebar + card content layout.
 struct AppMainWindow: View {
     @StateObject private var vm = AppViewModel()
+    private let baseWidth: CGFloat = 800
 
     var body: some View {
-        HStack(spacing: 0) {
-            SidebarView(selection: $vm.selection)
-                .frame(width: 220)
-                .background(.ultraThinMaterial)
+        GeometryReader { proxy in
+            let scale = max(proxy.size.width / baseWidth, 1.0)
+            HStack(spacing: 0) {
+                SidebarView(selection: $vm.selection)
+                    .frame(width: 220)
+                    .background(.ultraThinMaterial)
 
-            Divider()
+                Divider()
 
-            ScrollView {
-                VStack(alignment: .center, spacing: 16) {
-                    switch vm.selection {
-                    case .wallpaper: WallpaperView()
-                    case .playback: PlaybackSettingsView()
-                    case .general:  GeneralSettingsView()
+                ScrollView {
+                    VStack(alignment: .center, spacing: 16) {
+                        switch vm.selection {
+                        case .wallpaper: WallpaperView()
+                        case .playback: PlaybackSettingsView()
+                        case .general:  GeneralSettingsView()
+                        }
                     }
+                    .padding(20)
                 }
-                .padding(20)
             }
+            .scaleEffect(scale, anchor: .topLeading)
+            .frame(
+                width: proxy.size.width / scale,
+                height: proxy.size.height / scale,
+                alignment: .topLeading
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- scale main window text and icons based on window width
- document scaling behavior in change log

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b88b0e95a083309405ce1a681ded62