### PR TITLE
fix: avoid stopping shared players when switching video

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@
 # Desktop Video 更新日志
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
+### Version 4.0 Preview 0904 hot-fix 1 (2025-09-04)
+
+- 修复多屏幕相同视频时切换其中一屏视频导致的死循环
+- Prevent dead loop when changing video on one screen when both screens share the same video
 
 ### Version 4.0 Preview 0904 (2025-09-04)
 

--- a/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
+++ b/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
@@ -479,8 +479,23 @@ class SharedWallpaperWindowManager {
     private func stopVideoIfNeeded(for screen: NSScreen) {
         dlog("stop video if needed on \(screen.dv_localizedName)")
         let sid = id(for: screen)
-        players[sid]?.pause()
-        players[sid]?.replaceCurrentItem(with: nil)
+        guard let player = players[sid] else {
+            players.removeValue(forKey: sid)
+            loopers.removeValue(forKey: sid)
+            return
+        }
+
+        let isShared = players.contains { key, value in
+            key != sid && value === player
+        }
+
+        if !isShared {
+            player.pause()
+            player.replaceCurrentItem(with: nil)
+        } else {
+            dlog("skip stopping shared player for \(screen.dv_localizedName)")
+        }
+
         players.removeValue(forKey: sid)
         loopers.removeValue(forKey: sid)
     }


### PR DESCRIPTION
## Summary
- avoid stopping shared AVQueuePlayer when one screen switches video
- document fix in changelog

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3590d9c8330a5c1cd6ba0b413b1