### PR TITLE
fix: remove network update check

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,16 @@
 # Desktop Video 更新日志
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
+### Version 4.0 Preview 0909 hot-fix 2 (2025-09-09)
+
+- 使用 OSLog 将调试输出标记为 Debug 级别
+- Mark debug output using OSLog so it shows as Debug in console
+### Version 4.0 Preview 0909 hot-fix 1 (2025-09-09)
+
+- 移除 GitHub 更新检查以避免沙盒环境下的网络错误
+- 避免对壁纸窗口调用 makeKeyWindow 以消除系统警告
+- Remove GitHub update check to prevent sandbox network errors
+- Avoid calling makeKeyWindow on wallpaper window to eliminate system warnings
 ### Version 4.0 Preview 0905 hot-fix 1 (2025-09-05)
 
 - 限制 `windowScreenDidChange` 事件触发频率

--- a/Desktop Video/Desktop Video/AppDelegate.swift
+++ b/Desktop Video/Desktop Video/AppDelegate.swift
@@ -139,49 +139,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
        // Ensure shouldPauseVideo is evaluated once when the app launches
        updatePlaybackStateForAllScreens()
 
-       // 检查 GitHub 更新
-       checkForUpdates()
-   }
-
-   // MARK: - Update Check
-
-   /// 检查 GitHub 上是否有新版本并提示用户更新
-   private func checkForUpdates() {
-       dlog("checkForUpdates")
-       guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
-           return
-       }
-
-       let url = URL(string: "https://api.github.com/repos/TzJ2006/desktop-video-for-mac/releases/latest")!
-       let task = URLSession.shared.dataTask(with: url) { data, _, error in
-           if let error = error {
-               dlog("update check failed: \(error.localizedDescription)")
-               return
-           }
-           guard let data = data,
-                 let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                 let tag = json["tag_name"] as? String else {
-               dlog("update check parse failed")
-               return
-           }
-
-           dlog("latest tag \(tag) current \(currentVersion)")
-           guard tag != currentVersion else { return }
-
-           DispatchQueue.main.async {
-               let alert = NSAlert()
-               alert.messageText = L("UpdateAvailableTitle")
-               alert.informativeText = String(format: L("UpdateAvailableMessage"), tag)
-               alert.addButton(withTitle: L("UpdateNow"))
-               alert.addButton(withTitle: L("Later"))
-               if alert.runModal() == .alertFirstButtonReturn,
-                  let htmlURLString = json["html_url"] as? String,
-                  let htmlURL = URL(string: htmlURLString) {
-                   NSWorkspace.shared.open(htmlURL)
-               }
-           }
-       }
-       task.resume()
+       // 应用运行于沙盒环境，不再检查 GitHub 更新以避免网络错误
    }
 
    // MARK: - Screensaver Timer Methods
@@ -331,7 +289,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                wallpaperWindow.ignoresMouseEvents = false
                wallpaperWindow.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
                wallpaperWindow.alphaValue = 0 // 初始透明
-               wallpaperWindow.makeKeyAndOrderFront(nil)
+               // 仅将窗口置于最前，不请求键盘焦点以避免系统警告
+               wallpaperWindow.orderFront(nil)
 
                // 使用动画淡入
                NSAnimationContext.runAnimationGroup({ context in

--- a/Desktop Video/Desktop Video/Utils.swift
+++ b/Desktop Video/Desktop Video/Utils.swift
@@ -8,6 +8,7 @@
 import AppKit
 import Foundation
 import CoreGraphics
+import OSLog
 
 // MARK: - Notification 统一管理
 extension Notification.Name {
@@ -98,14 +99,25 @@ enum DVLogLevel: String {
     case error = "ERROR"
 }
 
+/// 统一日志记录器
+private let dvLogger = Logger(subsystem: "com.desktopvideo.wallpaper", category: "general")
+
 /// 调试日志，仅在 DEBUG 构建输出
 func dlog(_ message: String,
           level: DVLogLevel = .debug,
-          function: String = #function)
-{
-    // 1) 保留 Debug 模式下的控制台打印
+          function: String = #function) {
+    // 1) 使用统一日志系统输出到控制台
     #if DEBUG
-    print("[\(dvTimestamp())][\(level.rawValue)] \(function): \(message)")
+    switch level {
+    case .debug:
+        dvLogger.debug("\(function): \(message)")
+    case .info:
+        dvLogger.info("\(function): \(message)")
+    case .warn:
+        dvLogger.warning("\(function): \(message)")
+    case .error:
+        dvLogger.error("\(function): \(message)")
+    }
     #endif
 
     // 2) 委托给 LogFile 单例写入文件


### PR DESCRIPTION
## Summary
- avoid sandbox networking errors by removing GitHub update check
- prevent wallpaper window key-window warning
- classify debug logs as debug using OSLog
- document changes in changelog

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "Desktop Video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c06575dc9483308e828e6481070e13