### PR TITLE
fix: restore last wallpaper on new screens

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@
 # Desktop Video 更新日志
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
+### Version 4.0 Preview 0909 hot-fix 3 (2025-09-09)
+
+- 当仅连接外接显示器时自动恢复上次壁纸，避免黑屏
+- Automatically restore last wallpaper when only external displays are connected to avoid black screen
 ### Version 4.0 Preview 0909 hot-fix 2 (2025-09-09)
 
 - 使用 OSLog 将调试输出标记为 Debug 级别

--- a/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
+++ b/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
@@ -892,9 +892,21 @@ class SharedWallpaperWindowManager {
             }
           }
         }
-      } else {
+      } else if let _: Data = BookmarkStore.get(prefix: "bookmark", id: sid) {
         // 没有记录时尝试从书签恢复
         restoreFromBookmark(for: screen)
+      } else if let lastURL = AppState.shared.lastMediaURL {
+        dlog("apply last media for \(screen.dv_localizedName)")
+        let ext = lastURL.pathExtension.lowercased()
+        let stretch = AppState.shared.lastStretchToFill
+        let volume = AppState.shared.lastVolume
+        if ["mp4", "mov", "m4v"].contains(ext) {
+          showVideo(for: screen, url: lastURL, stretch: stretch, volume: volume)
+          saveBookmark(for: lastURL, stretch: stretch, volume: volume, screen: screen)
+        } else if ["jpg", "jpeg", "png", "heic"].contains(ext) {
+          showImage(for: screen, url: lastURL, stretch: stretch)
+          saveBookmark(for: lastURL, stretch: stretch, volume: nil, screen: screen)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure new external screens display last wallpaper when no bookmark is present
- record change in changelog

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c06c99ea008330806d8f1948c395a7