### PR TITLE
feat: add status bar video option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0909 hot-fix 1 (2025-09-10)
+
+- 新增在状态栏显示视频的开关
+- 全屏时状态栏背景与壁纸视频同步
+- Added toggle to show video in status bar
+- Status bar background now mirrors wallpaper video in full screen
+
 ### Version 4.0 Preview 0909 (2025-09-09)
 
 - 移除 GitHub 更新检查以避免沙盒环境下的网络错误

--- a/Desktop Video/Desktop Video/Localizable.xcstrings
+++ b/Desktop Video/Desktop Video/Localizable.xcstrings
@@ -614,6 +614,41 @@
         }
       }
     },
+    "ShowVideoInMenuBar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show video in menu bar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar video en la barra de menús"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la vidéo dans la barre de menus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在状态栏显示视频"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在狀態列顯示影片"
+          }
+        }
+      }
+    },
     "help": {
       "extractionState": "manual",
       "localizations": {

--- a/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
@@ -8,6 +8,7 @@ struct GeneralSettingsView: View {
     @AppStorage("selectedLanguage")  private var language:          String = "system"
     @AppStorage("maxVideoFileSizeInGB") private var maxVideoFileSizeInGB: Double = 1.0
     @AppStorage("globalMute") private var globalMute: Bool = false
+    @AppStorage("showMenuBarVideo") private var showMenuBarVideo: Bool = false
     @AppStorage("screensaverEnabled") private var screensaverEnabled: Bool = false
     @AppStorage("screensaverDelayMinutes") private var screensaverDelayMinutes: Double = 5.0
 
@@ -27,6 +28,11 @@ struct GeneralSettingsView: View {
             ToggleRow(title: LocalizedStringKey(L("GlobalMute")), value: $globalMute)
                 .onChange(of: globalMute) { newValue in
                     desktop_videoApp.applyGlobalMute(newValue)
+                }
+
+            ToggleRow(title: LocalizedStringKey(L("ShowVideoInMenuBar")), value: $showMenuBarVideo)
+                .onChange(of: showMenuBarVideo) { _ in
+                    SharedWallpaperWindowManager.shared.updateStatusBarVideoForAllScreens()
                 }
 
             ToggleRow(title: LocalizedStringKey(L("Auto sync new screens")), value: $autoSyncNewScreens)


### PR DESCRIPTION
## Summary
- add toggle to show wallpaper video in status bar
- sync status bar overlay with wallpaper playback
- document status bar video option in changelog

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "Desktop Video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d60622408330abd99f24e6e5d680