### PR TITLE
feat: add status bar video option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,17 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0909 hot-fix 1 (2025-09-10)
+
+- 新增在状态栏显示视频的开关
+- 全屏时状态栏背景仅显示壁纸视频上缘且不遮挡菜单文字
+- 在壁纸界面新增状态栏视频开关
+- 统一设置与界面中的菜单栏视频开关
+- Added toggle to show video in status bar
+- Status bar background crops to the top edge of the wallpaper video and stays behind menu text in full screen
+- Added menu bar video toggle to wallpaper screen
+- Unified menu bar video toggle between settings and wallpaper views
+
 ### Version 4.0 Preview 0909 (2025-09-09)
 
 - 移除 GitHub 更新检查以避免沙盒环境下的网络错误

--- a/Desktop Video/Desktop Video/Localizable.xcstrings
+++ b/Desktop Video/Desktop Video/Localizable.xcstrings
@@ -614,6 +614,41 @@
         }
       }
     },
+    "ShowVideoInMenuBar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show video in menu bar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar video en la barra de menús"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la vidéo dans la barre de menus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在状态栏显示视频"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在狀態列顯示影片"
+          }
+        }
+      }
+    },
     "help": {
       "extractionState": "manual",
       "localizations": {

--- a/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
+++ b/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
@@ -180,6 +180,8 @@ class SharedWallpaperWindowManager {
   var overlayWindows: [String: NSWindow] = [:]
   /// 全屏覆盖窗口，用于屏保启动前的遮挡检测
   var screensaverOverlayWindows: [String: NSWindow] = [:]
+  /// 状态栏视频窗口
+  var statusBarWindows: [String: NSWindow] = [:]
   var players: [String: AVQueuePlayer] = [:]
   var screenContent: [String: (type: ContentType, url: URL, stretch: Bool, volume: Float?)] = [:]
 
@@ -473,6 +475,9 @@ class SharedWallpaperWindowManager {
 
     // 清除暂停状态
     pausedScreens.remove(sid)
+
+    // 移除状态栏视频
+    updateStatusBarVideo(for: screen)
   }
 
   func restoreContent(for screen: NSScreen) {
@@ -521,6 +526,8 @@ class SharedWallpaperWindowManager {
     currentViews[sid] = newView
     // 内容切换完成后，根据遮挡状态重新评估播放/暂停
     updatePlayState(for: screen)
+    // 根据设置更新状态栏视频
+    updateStatusBarVideo(for: screen)
   }
 
   /// 根据 overlay 遮挡状态立即决定播放或暂停该屏幕的视频
@@ -562,6 +569,69 @@ class SharedWallpaperWindowManager {
   /// 供外部在遮挡状态变更时调用，确保每屏独立刷新
   func refreshPlayState(for screen: NSScreen) {
     updatePlayState(for: screen)
+  }
+
+  /// 根据用户设置在状态栏显示或移除视频
+  func updateStatusBarVideo(for screen: NSScreen) {
+    let sid = id(for: screen)
+    let enabled = UserDefaults.standard.bool(forKey: "showMenuBarVideo")
+    guard enabled, let player = players[sid] else {
+      if let win = statusBarWindows[sid] {
+        dlog("remove status bar video on \(screen.dv_localizedName)")
+        win.orderOut(nil)
+        statusBarWindows.removeValue(forKey: sid)
+      }
+      return
+    }
+
+    dlog("update status bar video on \(screen.dv_localizedName)")
+    let barHeight = NSStatusBar.system.thickness
+    let screenFrame = screen.frame
+    let frame = CGRect(
+      x: screenFrame.minX, y: screenFrame.maxY - barHeight, width: screenFrame.width,
+      height: barHeight)
+
+    let win: NSWindow
+    if let existing = statusBarWindows[sid] {
+      win = existing
+      win.setFrame(frame, display: true)
+    } else {
+      win = NSWindow(
+        contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+      win.level = NSWindow.Level(Int(CGWindowLevelForKey(.backstopMenu)))
+      win.isOpaque = false
+      win.backgroundColor = .clear
+      win.ignoresMouseEvents = true
+      win.collectionBehavior = [.canJoinAllSpaces, .stationary]
+      win.contentView?.wantsLayer = true
+      win.contentView?.layer?.masksToBounds = true
+      let viewFrame = CGRect(
+        x: 0, y: barHeight - screenFrame.height, width: screenFrame.width,
+        height: screenFrame.height)
+      let view = AVPlayerView(frame: viewFrame)
+      view.controlsStyle = .none
+      view.videoGravity = .resizeAspectFill
+      view.autoresizingMask = [.width]
+      win.contentView?.addSubview(view)
+      statusBarWindows[sid] = win
+    }
+
+    if let view = win.contentView?.subviews.first as? AVPlayerView {
+      view.player = player
+      view.frame = CGRect(
+        x: 0, y: barHeight - screenFrame.height, width: screenFrame.width,
+        height: screenFrame.height)
+    }
+
+    win.orderFrontRegardless()
+  }
+
+  /// 更新所有屏幕的状态栏视频
+  func updateStatusBarVideoForAllScreens() {
+    dlog("update status bar video for all screens")
+    for screen in NSScreen.screens {
+      updateStatusBarVideo(for: screen)
+    }
   }
 
   func updateBookmark(stretch: Bool, volume: Float?, screen: NSScreen) {

--- a/Desktop Video/Desktop Video/UI/Components/MenuBarVideoToggle.swift
+++ b/Desktop Video/Desktop Video/UI/Components/MenuBarVideoToggle.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct MenuBarVideoToggle: View {
+    @AppStorage("showMenuBarVideo") private var showMenuBarVideo: Bool = false
+
+    var body: some View {
+        ToggleRow(title: LocalizedStringKey(L("ShowVideoInMenuBar")), value: $showMenuBarVideo)
+            .onChange(of: showMenuBarVideo) { newValue in
+                dlog("showMenuBarVideo changed to \(newValue)")
+                SharedWallpaperWindowManager.shared.updateStatusBarVideoForAllScreens()
+            }
+    }
+}

--- a/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
@@ -29,6 +29,8 @@ struct GeneralSettingsView: View {
                     desktop_videoApp.applyGlobalMute(newValue)
                 }
 
+            MenuBarVideoToggle()
+
             ToggleRow(title: LocalizedStringKey(L("Auto sync new screens")), value: $autoSyncNewScreens)
                 .onChange(of: autoSyncNewScreens) { newValue in
                     guard !isReverting else { isReverting = false; return }

--- a/Desktop Video/Desktop Video/UI/Screens/WallpaperView.swift
+++ b/Desktop Video/Desktop Video/UI/Screens/WallpaperView.swift
@@ -26,6 +26,8 @@ struct WallpaperView: View {
                 SingleScreenView(screen: screen)
             }
 
+            MenuBarVideoToggle()
+
             ToggleRow(title: LocalizedStringKey(L("Show only in menu bar")), value: Binding(
                 get: { menuBarOnly },
                 set: {


### PR DESCRIPTION
## Summary
- add toggle to show wallpaper video in status bar
- crop wallpaper's top edge into menu bar background without covering status items
- expose same menu bar video toggle on wallpaper screen for quick access
- unify menu bar video toggle between settings and wallpaper screens
- document status bar video option in changelog

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "Desktop Video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d60622408330abd99f24e6e5d680