### PR TITLE
fix: replace auto screen sync with manual same-video sync

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0909 hot-fix 2 (2025-09-10)
+
+- 移除屏幕自动同步以修复死循环问题
+- 新增按钮以手动同步同名视频的播放进度
+- Remove automatic screen sync to prevent dead loop
+- Add button to manually sync same-name videos to the same pace
+
 ### Version 4.0 Preview 0909 hot-fix 1 (2025-09-10)
 
 - 新增在状态栏显示视频的开关
@@ -12,12 +19,14 @@
 - 修复状态栏不显示视频的问题
 - 修复“拉伸以填充”设置无效的问题
 - 将“在状态栏显示视频”选项移动至通用设置
+- 在状态栏中按正确比例显示视频背景
 - Added toggle to show video in status bar
 - Status bar background crops to the top edge of the wallpaper video and stays behind menu text in full screen
 - Fix issue where clearing video failed
 - Fix issue where video did not appear in status bar
 - Fix stretch-to-fill setting not applying
 - Move “Show video in status bar” option to General settings
+- Keep status bar video at correct aspect ratio
 
 
 ### Version 4.0 Preview 0909 (2025-09-09)

--- a/Desktop Video/Desktop Video/Desktop_VideoApp.swift
+++ b/Desktop Video/Desktop Video/Desktop_VideoApp.swift
@@ -20,7 +20,6 @@ struct desktop_videoApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     // 这些 AppStorage 只在菜单命令里保持最新状态，不直接绑定到 PreferencesView
-    @AppStorage("autoSyncNewScreens") private var autoSyncNewScreens: Bool = true
     @AppStorage("launchAtLogin")     private var launchAtLogin:     Bool = true
     @AppStorage("globalMute")        var globalMute:        Bool = false
 
@@ -99,7 +98,6 @@ struct desktop_videoApp: App {
 /// **首选项面板**：在 Settings 窗口中显示，修改延迟到"确认"后才写入
 struct PreferencesView: View {
     // 真正存储的 AppStorage
-    @AppStorage("autoSyncNewScreens") private var autoSyncNewScreensStorage: Bool = true
     @AppStorage("launchAtLogin")     private var launchAtLoginStorage:     Bool = true
     @AppStorage("globalMute")        private var globalMuteStorage:        Bool = false
     @AppStorage("selectedLanguage")  private var languageStorage:          String = "system"
@@ -111,7 +109,6 @@ struct PreferencesView: View {
     @ObservedObject private var appState = AppState.shared
 
     // 本地 State，用于暂存用户在界面上的修改
-    @State private var autoSyncNewScreens: Bool = true
     @State private var launchAtLogin:     Bool = true
     @State private var globalMute:        Bool = false
     @State private var selectedLanguage:  String = "system"
@@ -122,7 +119,6 @@ struct PreferencesView: View {
     @State private var playbackMode: AppState.PlaybackMode = .alwaysPlay
 
     // 原始值缓存，用于恢复
-    @State private var originalAutoSyncNewScreens: Bool = true
     @State private var originalLaunchAtLogin:     Bool = true
     @State private var originalGlobalMute:        Bool = false
     @State private var originalSelectedLanguage:  String = "system"
@@ -134,8 +130,7 @@ struct PreferencesView: View {
 
     /// 是否有未保存的更改
     private var hasChanges: Bool {
-        autoSyncNewScreens != autoSyncNewScreensStorage
-        || launchAtLogin != launchAtLoginStorage
+        launchAtLogin != launchAtLoginStorage
         || globalMute != globalMuteStorage
         || selectedLanguage != languageStorage
         || idlePauseSensitivity != appState.idlePauseSensitivity
@@ -148,8 +143,7 @@ struct PreferencesView: View {
     /// 是否需要重启应用才能完全生效
     private var requiresRestart: Bool {
         // 语言、屏幕同步等需要重建窗口；播放模式 / 静音等则可即时生效
-        autoSyncNewScreens != autoSyncNewScreensStorage
-        || launchAtLogin != launchAtLoginStorage
+        launchAtLogin != launchAtLoginStorage
         || selectedLanguage != languageStorage
         || screensaverEnabled != screensaverEnabledStorage
         || screensaverDelayMinutes != screensaverDelayMinutesStorage
@@ -164,7 +158,6 @@ struct PreferencesView: View {
             VStack(spacing: 12) {
                 Toggle(L("GlobalMute"), isOn: $globalMute)
                 Toggle(L("LaunchAtLogin"), isOn: $launchAtLogin)
-                Toggle(L("AutoSyncNewScreens"), isOn: $autoSyncNewScreens)
 
                 HStack {
                     Text(L("Language"))
@@ -242,7 +235,6 @@ struct PreferencesView: View {
         .padding(20)
         .onAppear {
             // 首次出现时缓存原始值
-            originalAutoSyncNewScreens = autoSyncNewScreensStorage
             originalLaunchAtLogin = launchAtLoginStorage
             originalGlobalMute = globalMuteStorage
             originalSelectedLanguage = languageStorage
@@ -260,7 +252,6 @@ struct PreferencesView: View {
 
     private func loadStoredValues() {
         dlog("loadStoredValues")
-        autoSyncNewScreens = originalAutoSyncNewScreens
         launchAtLogin = originalLaunchAtLogin
         globalMute = originalGlobalMute
         selectedLanguage = originalSelectedLanguage
@@ -274,7 +265,6 @@ struct PreferencesView: View {
     private func confirmChanges() {
         dlog("confirmChanges")
         // 只保存设置到 AppStorage，但不立即应用
-        autoSyncNewScreensStorage = autoSyncNewScreens
         launchAtLoginStorage = launchAtLogin
         globalMuteStorage = globalMute
         languageStorage = selectedLanguage

--- a/Desktop Video/Desktop Video/Localizable.xcstrings
+++ b/Desktop Video/Desktop Video/Localizable.xcstrings
@@ -86,76 +86,6 @@
         }
       }
     },
-    "Auto sync new screens": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto sync new screens"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronizar pantallas nuevas automáticamente"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synchroniser automatiquement les nouveaux écrans"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自动同步新插入的显示器"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動同步新插入的顯示器"
-          }
-        }
-      }
-    },
-    "AutoSyncNewScreens": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto sync to new displays"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sincronización automática con nuevas pantallas"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synchroniser automatiquement les écrans nouvellement connectés"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自动同步新插入的显示器"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動同步新插入的顯示器"
-          }
-        }
-      }
-    },
     "ChangeFile": {
       "extractionState": "manual",
       "localizations": {
@@ -1185,37 +1115,37 @@
         }
       }
     },
-    "Sync to all screens": {
+    "Sync same videos": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sync to all screens"
+            "value": "Sync same videos"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sincronizar con todas las pantallas"
+            "value": "Sincronizar videos iguales"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Synchroniser sur tous les écrans"
+            "value": "Synchroniser les vidéos identiques"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "同步到所有屏幕"
+            "value": "同步相同视频"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "同步到所有螢幕"
+            "value": "同步相同影片"
           }
         }
       }

--- a/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
+++ b/Desktop Video/Desktop Video/UI/Screens/GeneralSettingsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import ServiceManagement
 
 struct GeneralSettingsView: View {
-    @AppStorage("autoSyncNewScreens") private var autoSyncNewScreens: Bool = true
     @AppStorage("launchAtLogin")     private var launchAtLogin:     Bool = true
     @AppStorage("selectedLanguage")  private var language:          String = "system"
     @AppStorage("maxVideoFileSizeInGB") private var maxVideoFileSizeInGB: Double = 1.0
@@ -14,7 +13,6 @@ struct GeneralSettingsView: View {
 
     @ObservedObject private var appState = AppState.shared
 
-    @State private var originalAutoSyncNewScreens = UserDefaults.standard.bool(forKey: "autoSyncNewScreens")
     @State private var originalLaunchAtLogin = UserDefaults.standard.bool(forKey: "launchAtLogin")
     @State private var originalLanguage = UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system"
     @State private var originalMaxVideoFileSizeInGB = UserDefaults.standard.double(forKey: "maxVideoFileSizeInGB")
@@ -32,18 +30,6 @@ struct GeneralSettingsView: View {
 
             MenuBarVideoToggle()
 
-            ToggleRow(title: LocalizedStringKey(L("Auto sync new screens")), value: $autoSyncNewScreens)
-                .onChange(of: autoSyncNewScreens) { newValue in
-                    guard !isReverting else { isReverting = false; return }
-                    dlog("autoSyncNewScreens changed to \(newValue), restart required")
-                    let previous = originalAutoSyncNewScreens
-                    desktop_videoApp.showRestartAlert {
-                        originalAutoSyncNewScreens = newValue
-                    } onDiscard: {
-                        isReverting = true
-                        autoSyncNewScreens = previous
-                    }
-                }
             ToggleRow(title: LocalizedStringKey(L("Launch at login")), value: Binding(
                 get: { launchAtLogin },
                 set: {

--- a/Desktop Video/Desktop Video/UI/Screens/SingleScreenView.swift
+++ b/Desktop Video/Desktop Video/UI/Screens/SingleScreenView.swift
@@ -19,7 +19,7 @@ struct SingleScreenView: View {
                 Button(action: clear) { Text(L("Clear")) }
                 Button(action: play) { Text(L("Play")) }
                 Button(action: pause) { Text(L("Pause")) }
-                Button(action: syncAll) { Text(L("Sync to all screens")) }
+                Button(action: syncAll) { Text(L("Sync same videos")) }
             }
             if !currentFileName.isEmpty {
                 HStack(spacing: 4) {
@@ -109,8 +109,8 @@ struct SingleScreenView: View {
 
     // 将当前屏幕的视频同步到所有屏幕
     private func syncAll() {
-        dlog("sync to all screens from \(screen.dv_localizedName)")
-        SharedWallpaperWindowManager.shared.syncAllWindows(sourceScreen: screen)
+        dlog("sync same-name videos across screens")
+        SharedWallpaperWindowManager.shared.syncSameNamedVideos()
     }
 
     private func updateStretch(_ stretch: Bool) {


### PR DESCRIPTION
## Summary
- remove automatic screen synchronization and stop syncing new displays
- add manual "Sync same videos" button to align playback across screens with identical filenames
- document manual sync feature and auto-sync removal in changelog

## Testing
- `xcodebuild -project "desktop video/desktop video.xcodeproj" -scheme "desktop video" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e0d910ac8330ad71db956089225e