### PR TITLE
fix: mark SharedWallpaperWindowManager as MainActor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0909 hot-fix 8 (2025-09-14)
+
+- 使用 `@MainActor` 注解 `SharedWallpaperWindowManager`，修复 `tearDownWindow` 并发编译错误
+- Annotate `SharedWallpaperWindowManager` with `@MainActor` to fix `tearDownWindow` concurrency build errors
+- 清理重复的覆盖层移除逻辑，防止窗口状态不一致
+- Remove duplicate overlay cleanup to avoid inconsistent window state
+
 ### Version 4.0 Preview 0909 hot-fix 7 (2025-09-13)
 
 - 强化 WallpaperWindow 生命周期管理，防止 Zombie 崩溃

--- a/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
+++ b/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
@@ -12,6 +12,7 @@ import CoreGraphics  // for CGWindowListCopyWindowInfo
 import Foundation
 import UniformTypeIdentifiers
 
+@MainActor
 class SharedWallpaperWindowManager {
   static let shared = SharedWallpaperWindowManager()
 
@@ -159,7 +160,7 @@ class SharedWallpaperWindowManager {
   private var savedVolumes: [String: Float] = [:]
   private var currentViews: [String: NSView] = [:]
   private var loopers: [String: AVPlayerLooper] = [:]
-  @MainActor private var windowControllers: [String: WallpaperWindowController] = [:]
+  private var windowControllers: [String: WallpaperWindowController] = [:]
   /// 用于检测遮挡状态的小窗口（每个屏幕四个）
   var overlayWindows: [String: NSWindow] = [:]
   /// 全屏覆盖窗口，用于屏保启动前的遮挡检测
@@ -186,7 +187,7 @@ class SharedWallpaperWindowManager {
     return data
   }
 
-  @MainActor private func setupWindow(for screen: NSScreen) {
+  private func setupWindow(for screen: NSScreen) {
     dlog("ensure window for \(screen.dv_localizedName)")
     let sid = id(for: screen)
     if windowControllers[sid] != nil {
@@ -292,7 +293,7 @@ class SharedWallpaperWindowManager {
     updatePlayState(for: screen)
   }
 
-  @MainActor private func tearDownWindow(for screen: NSScreen) {
+  private func tearDownWindow(for screen: NSScreen) {
     let sid = id(for: screen)
     if let controller = windowControllers.removeValue(forKey: sid) {
       controller.stop()
@@ -525,8 +526,6 @@ class SharedWallpaperWindowManager {
         AppState.shared.currentMediaURL = nil
       }
     }
-    overlayWindows.removeValue(forKey: sid)
-    screensaverOverlayWindows.removeValue(forKey: sid)
     if let statusWin = statusBarWindows[sid] {
       statusWin.orderOut(nil)
       statusBarWindows.removeValue(forKey: sid)


### PR DESCRIPTION
## Summary
- ensure `SharedWallpaperWindowManager` always executes on the main actor to resolve `tearDownWindow` isolation errors
- remove duplicate overlay cleanup to avoid inconsistent window state
- document hot-fix

## Testing
- `xcodebuild   -project "Desktop Video/Desktop Video.xcodeproj"   -scheme "Desktop Video"   -destination "platform=macOS"   clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6164e16bc83308164563858f69bf1